### PR TITLE
Issue 172 send email

### DIFF
--- a/geonode/invitations/views.py
+++ b/geonode/invitations/views.py
@@ -97,11 +97,8 @@ class GeoNodeSendInvite(SendInvite):
         })
 
         email_template = 'invitations/email/email_invite'
-
-        get_invitations_adapter().send_mail(
-            email_template,
-            invite.email,
-            ctx)
+        adapter = get_invitations_adapter()
+        adapter.send_invitation_email(email_template, invite.email, ctx)
         invite.sent = timezone.now()
         invite.save()
 

--- a/geonode/messaging/__init__.py
+++ b/geonode/messaging/__init__.py
@@ -18,6 +18,7 @@
 #
 #########################################################################
 from django.conf import settings
+
 from geonode.notifications_helper import NotificationsAppConfigBase
 
 connections = None
@@ -56,6 +57,9 @@ class MessagingAppConfig(NotificationsAppConfigBase):
         broker_transport_options = getattr(settings, 'BROKER_TRANSPORT_OPTIONS', {'socket_timeout': 10})
         broker_socket_timeout = getattr(broker_transport_options, 'socket_timeout', 10)
         connection = BrokerConnection(url, connect_timeout=broker_socket_timeout)
+
+        from geonode.messaging.notifications import initialize_notification_signal
+        initialize_notification_signal()
 
 
 default_app_config = 'geonode.messaging.MessagingAppConfig'

--- a/geonode/messaging/notifications.py
+++ b/geonode/messaging/notifications.py
@@ -1,0 +1,40 @@
+from geonode.celery_app import app
+from django.conf import settings
+from user_messages.models import Message, Thread
+from user_messages.signals import message_sent
+
+
+@app.task(queue='email')
+def notify_thread_participants(thread_id, message_id):
+    email_template = 'user_messages/email/email_new_message'
+    message = Message.objects.get(pk=message_id)
+    thread = Thread.objects.get(pk=thread_id)
+    msg_sender = message.sender
+    users = thread.registered_users
+    groups = thread.registered_groups
+    ctx = {
+        'message': message.content,
+        'thread_subject': thread.subject,
+        'sender': message.sender,
+        'thread_url': settings.SITEURL + thread.get_absolute_url()[1:],
+        'logo_url': f'{settings.SITEURL}static/img/logo_ihp_alpha_small.png'
+    }
+    for group in groups:
+        users |= group.user_set.all().distinct()
+
+    users = users.exclude(pk=msg_sender.pk)
+    for user in users:
+        user.send_mail(email_template, ctx)
+
+
+def notify_thread_participants_wrap(**kwargs):
+    thread = kwargs.get('thread').pk
+    message = kwargs.get('message').pk
+    notify_thread_participants.delay(thread_id=thread, message_id=message)
+
+
+def initialize_notification_signal():
+    message_sent.connect(
+        notify_thread_participants_wrap,
+        sender=Message
+    )

--- a/geonode/people/adapters.py
+++ b/geonode/people/adapters.py
@@ -128,11 +128,13 @@ class LocalAccountAdapter(DefaultAccountAdapter, BaseInvitationsAdapter):
             ])
         user_username(user, safe_username)
 
-    def render_mail(self, template_prefix, email, context):
+    def send_invitation_email(self, email_template, email, context):
+        enh_context = self.enhanced_invitation_context(context)
+        self.send_mail(email_template, email, enh_context)
+
+    def enhanced_invitation_context(self, context):
         user = context.get("inviter") if context.get("inviter") else context.get("user")
         full_name = " ".join((user.first_name, user.last_name)) if user.first_name or user.last_name else None
-        # manager_groups = Group.objects.filter(
-        #     name__in=user.groupmember_set.filter(role="manager").values_list("group__slug", flat=True))
         user_groups = GroupProfile.objects.filter(
             slug__in=user.groupmember_set.filter().values_list("group__slug", flat=True))
         enhanced_context = context.copy()
@@ -146,12 +148,7 @@ class LocalAccountAdapter(DefaultAccountAdapter, BaseInvitationsAdapter):
             "SITEURL": settings.SITEURL,
             "STATIC_URL": settings.STATIC_URL
         })
-        return super(LocalAccountAdapter, self).render_mail(
-            template_prefix, email, enhanced_context)
-
-    def send_mail(self, template_prefix, email, context):
-        msg = self.render_mail(template_prefix, email, context)
-        msg.send()
+        return enhanced_context
 
     def save_user(self, request, user, form, commit=True):
         user = super(LocalAccountAdapter, self).save_user(

--- a/geonode/people/models.py
+++ b/geonode/people/models.py
@@ -21,6 +21,7 @@
 from uuid import uuid4
 import logging
 
+from allauth.account.adapter import get_adapter
 from django.conf import settings
 
 from django.db import models
@@ -219,14 +220,15 @@ class Profile(AbstractUser):
                 }
 
                 email_template = 'pinax/notifications/account_active/account_active'
-
-                get_invitations_adapter().send_mail(
-                    email_template,
-                    self.email,
-                    ctx)
+                adapter = get_invitations_adapter()
+                adapter.send_invitation_email(email_template, self.email, ctx)
             except Exception:
                 import traceback
                 traceback.print_exc()
+
+    def send_mail(self, template_prefix, context):
+        if self.email:
+            get_adapter().send_mail(template_prefix, self.email, context)
 
 
 def get_anonymous_user_instance(user_model):

--- a/geonode/templates/user_messages/email/email_new_message_message.txt
+++ b/geonode/templates/user_messages/email/email_new_message_message.txt
@@ -1,0 +1,8 @@
+{% load i18n %}
+{% autoescape off %}
+
+You received a new message from {{ sender }}. Click the link below to view the message:
+
+{{ thread_url }}
+
+{% endautoescape %}

--- a/geonode/templates/user_messages/email/email_new_message_subject.txt
+++ b/geonode/templates/user_messages/email/email_new_message_subject.txt
@@ -1,0 +1,4 @@
+{% load i18n %}
+{% autoescape off %}
+New message in inbox in thread {{ thread_subject }}
+{% endautoescape %}

--- a/geonode/tests/test_message_notifications.py
+++ b/geonode/tests/test_message_notifications.py
@@ -1,0 +1,23 @@
+from user_messages.models import Thread, Message
+from geonode.messaging.notifications import notify_thread_participants
+from geonode.people.models import Profile
+from geonode.tests.base import GeoNodeBaseTestSupport
+from unittest.mock import patch
+
+
+class TestSendEmail(GeoNodeBaseTestSupport):
+
+    def setUp(self):
+        self.p = Profile.objects.create(username='test', email='test1@test.test')
+        self.p1 = Profile.objects.create(username='test1')
+        self.sender = Profile.objects.create(username='sender', email='test1@test.test')
+        self.t = Thread.objects.create(subject='test')
+        self.t.single_users.add(self.p)
+        self.t.single_users.add(self.p1)
+        self.m = Message.objects.create(content='test', thread=self.t, sender=self.sender)
+
+    @patch('django.core.mail.message.EmailMessage.send')
+    def test_emails_sent(self, email_message):
+        notify_thread_participants(self.t.pk, self.m.pk)
+        email_message.assert_called_once()
+        pass


### PR DESCRIPTION
Issue:
https://github.com/geosolutions-it/unesco-ihp/issues/172

I made a decision that the account adapter is the true source of sending logic. 
User has send_email method but it utilizes Account adapter. Profile send email in particular user context, it is using user email as destination, while Account adapter is the context free.

send_email and render_email methods was removed from LocalAccountAdapter they were overridden in way which breaks their versatile usage.  Code connected with invitation template was written there, i moveid it to another method which is called in right places 

Neither profile send_email nor adapter send_email are celery tasks. Celery is not able to serialize selfs and other objects passed to template context, so code is wrapped into method with simple parameters, then objects are retrieved inside 


Customization for unesco is still required
