### PR TITLE
force group view to use groupprofile endpoint since it was utilizing …

### DIFF
--- a/geonode/groups/templates/groups/_group_profile_list_item.html
+++ b/geonode/groups/templates/groups/_group_profile_list_item.html
@@ -1,32 +1,37 @@
 {% verbatim %}
 <article ng-repeat="group in results" ng-cloak class="ng-cloak">
-  <div class="col-xs-12 col-sm-6 col-lg-4 group-container">
-    <div class="col-xs-12 group-avatar">
-      <div class="col-xs-4 group-image">
-        <a ng-if="group.group_profile.logo_url != ''" href="{{ group.group_profile.detail_url }}"><img
-            ng-if="group.group_profile.logo_url != ''" ng-src="{{ group.group_profile.logo_url }}"
-            alt="{{ group.group_profile.title }}" class="group-logo" /></a>
-      </div>
-      <div class="col-xs-8 group-details">
-        <h5><a href="{{ group.group_profile.detail_url }}"></a></h5>
-        <!-- <a href="mailto:{{ group.group_profile.email }}" ng-if="group.group_profile.email != ''"><i class="fa fa-envelope-o"></i></a> -->
-        <p><small>{{ group.group_profile.description | limitTo: 100 }}{{ group.group_profile.description.length  > 100 ? '...' : ''}}</small></p>
-      </div>
-      <div class="col-xs-12 group-items">
-        <ul class="list-inline">
-          <li>
-        <a href="{{ group.group_profile.detail_url}}">
-          <strong>{{ group.group_profile.member_count }}</strong>
-          <ng-pluralize count="group.group_profile.member_count" when="{'1': 'Member', 'other': 'Members'}"></ng-pluralize>
-        </a>
-      </li>
-      <li>
-        <a href="{{ group.group_profile.detail_url }}">
-          <strong>{{ group.group_profile.manager_count }}</strong>
-          <ng-pluralize count="group.group_profile.manager_count" when="{'1': 'Manager', 'other': 'Managers'}"></ng-pluralize>
-        </a>
-      </li>
+    <div class="col-xs-12 col-sm-6 col-lg-4 group-container">
+        <div class="col-xs-12 group-avatar">
+            <div class="col-xs-4 group-image">
+                <a ng-if="group.group_profile.logo_url != ''" href="{{ group.group_profile.detail_url }}"><img
+                        ng-if="group.group_profile.logo_url != ''" ng-src="{{ group.group_profile.logo_url }}"
+                        alt="{{ group.group_profile.title }}" class="group-logo"/></a>
+            </div>
+            <div class="col-xs-8 group-details">
+                <h5><a href="{{ group.group_profile.detail_url }}"></a></h5>
+                <!-- <a href="mailto:{{ group.group_profile.email }}" ng-if="group.group_profile.email != ''"><i class="fa fa-envelope-o"></i></a> -->
+                <p><small>{{ group.group_profile.description | limitTo: 100 }}{{ group.group_profile.description.length
+                    > 100 ? '...' : ''}}</small></p>
+            </div>
+            <div class="col-xs-12 group-items">
+                <ul class="list-inline">
+                    <li>
+                        <a href="{{ group.group_profile.detail_url}}">
+                            <strong>{{ group.group_profile.member_count }}</strong>
+                            <ng-pluralize count="group.group_profile.member_count"
+                                          when="{'1': 'Member', 'other': 'Members'}"></ng-pluralize>
+                        </a>
+                    </li>
+                    <li>
+                        <a href="{{ group.group_profile.detail_url }}">
+                            <strong>{{ group.group_profile.manager_count }}</strong>
+                            <ng-pluralize count="group.group_profile.manager_count"
+                                          when="{'1': 'Manager', 'other': 'Managers'}"></ng-pluralize>
+                        </a>
+                    </li>
+                </ul>
+            </div>
+        </div>
     </div>
-  </div>
 </article>
 {% endverbatim %}

--- a/geonode/groups/templates/groups/group_list.html
+++ b/geonode/groups/templates/groups/group_list.html
@@ -25,7 +25,7 @@
 {% block extra_script %}
 {{ block.super }}
   <script type="text/javascript">
-  SEARCH_URL = '{% url 'api_dispatch_list' api_name='api' resource_name='groups' %}'
+  SEARCH_URL = '{% url 'api_dispatch_list' api_name='api' resource_name='group_profile' %}'
   </script>
   {% with include_spatial='false' %}
   {% include 'search/search_scripts.html' %}

--- a/geonode/templates/search/_group_snippet.html
+++ b/geonode/templates/search/_group_snippet.html
@@ -1,38 +1,39 @@
 {% verbatim %}
 <div class="row">
-  <article ng-repeat="group in results" resource_id="{{ group.id }}" ng-cloak class="ng-cloak">
-    <div class="col-xs-12 item-container">
-        <div class="col-xs-4">
-            <img class="img-responsive" ng-src="{{ group.group_profile.logo_url }}" alt="{{ group.group_profile.title }}">
-        </div>
-        <div class="col-xs-8 item-details">
-          <h4><a href="{{ group.group_profile.detail_url }}">{{ group.group_profile.title }}</a></h4>
-          <p class="abstract">
-              {{ group.group_profile.description | limitTo: 300 }}
-              {{ group.group_profile.description.length  > 300 ? '...' : ''}}
-          </p>
-          <div class="row">
-            <div class="col-xs-12 item-items">
-              <ul class="list-inline">
-                <li>
-                    <a href="{{ group.group_profile.detail_url }}">
-                      <strong>{{ group.group_profile.member_count }}</strong>
-                      <ng-pluralize count="group.group_profile.member_count" when="{'1': 'Member', 'other': 'Members'}"></ng-pluralize>
-                    </a>
-                </li>
-                <li>
-                    <a href="{{ group.group_profile.detail_url }}">
-                        <strong>{{ group.group_profile.manager_count }}</strong>
-                        <ng-pluralize count="group.group_profile.manager_count" when="{'1': 'Manager', 'other': 'Managers'}"></ng-pluralize>
-                    </a>
-                </li>
-                <li>{{ group.created|date:"d.M.y" }}</li>
-              </ul>
+    <article ng-repeat="group_profile in results" resource_id="{{ id }}" ng-cloak class="ng-cloak">
+        <div class="col-xs-12 item-container">
+            <div class="col-xs-4">
+                <img class="img-responsive" ng-src="{{ group_profile.logo_url }}" alt="{{ group_profile.title }}">
             </div>
-          </div>
+            <div class="col-xs-8 item-details">
+                <h4><a href="{{ group_profile.detail_url }}">{{ group_profile.title }}</a></h4>
+                <p class="abstract">
+                    {{ group_profile.description | limitTo: 300 }}
+                    {{ group_profile.description.length > 300 ? '...' : ''}}
+                </p>
+                <div class="row">
+                    <div class="col-xs-12 item-items">
+                        <ul class="list-inline">
+                            <li>
+                                <a href="{{ group_profile.detail_url }}">
+                                    <strong>{{ group_profile.member_count }}</strong>
+                                    <ng-pluralize count="group_profile.member_count"
+                                                  when="{'1': 'Member', 'other': 'Members'}"></ng-pluralize>
+                                </a>
+                            </li>
+                            <li>
+                                <a href="{{ group_profile.detail_url }}">
+                                    <strong>{{ group_profile.manager_count }}</strong>
+                                    <ng-pluralize count="group_profile.manager_count"
+                                                  when="{'1': 'Manager', 'other': 'Managers'}"></ng-pluralize>
+                                </a>
+                            </li>
+                            <li>{{ created|date:"d.M.y" }}</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
         </div>
-      </div>
-    </div>
-  </article>
+    </article>
 </div>
 {% endverbatim %}


### PR DESCRIPTION
Group view is using group profile endpoint since it is consuming its data anyway.
fix HTML structure in groupprofile_list_item.html

Note to consider:
It looks like _group_profile_list_item is used in one place: in group category detail. It is also consuming group profile data but it hits group resource. I think it should be rewrited to group profile too. Besides if it is the last place where group resource is used we can remove that endpoint 