### PR TITLE
Issue 21 users and groups filter

### DIFF
--- a/geonode/api/api.py
+++ b/geonode/api/api.py
@@ -40,7 +40,7 @@ from tastypie.exceptions import BadRequest
 from geonode import qgis_server, geoserver
 from geonode.api.paginator import CrossSiteXHRPaginator
 from geonode.api.authorization import GeoNodeStyleAuthorization, ApiLockdownAuthorization, \
-    GroupAuthorization, GroupProfileAuthorization
+    GroupAuthorization, GroupProfileAuthorization, ProfileAuthorization
 from geonode.qgis_server.models import QGISServerStyle
 from guardian.shortcuts import get_objects_for_user
 from tastypie.bundle import Bundle
@@ -540,7 +540,7 @@ class ProfileResource(TypeFilteredResource):
             'username': ALL,
         }
         serializer = CountJSONSerializer()
-        authorization = ApiLockdownAuthorization()
+        authorization = ProfileAuthorization()
 
 
 class OwnersResource(TypeFilteredResource):

--- a/geonode/documents/templates/documents/document_thumb_upload.html
+++ b/geonode/documents/templates/documents/document_thumb_upload.html
@@ -81,8 +81,7 @@
       csrf_token =  "{{ csrf_token }}",
       form_target = "{% url "document_thumb_upload" docid=resource.id %}",
       time_enabled = false,
-      mosaic_enabled = false,
-      userLookup = "{% url "account_ajax_lookup" %}"
+      mosaic_enabled = false
     {% endautoescape %}
     </script>
     {% if GEONODE_SECURITY_ENABLED %}

--- a/geonode/layers/templates/layers/layer_metadata_upload.html
+++ b/geonode/layers/templates/layers/layer_metadata_upload.html
@@ -130,8 +130,7 @@
       csrf_token =  "{{ csrf_token }}",
       form_target = "{{ LAYER_ANCILLARY_FILES_UPLOAD_URL }}",
       time_enabled = false,
-      mosaic_enabled = false,
-      userLookup = "{% url "account_ajax_lookup" %}"
+      mosaic_enabled = false
 
     {% endautoescape %}
 

--- a/geonode/layers/templates/layers/layer_replace.html
+++ b/geonode/layers/templates/layers/layer_replace.html
@@ -139,8 +139,7 @@
   csrf_token =  "{{ csrf_token }}",
   form_target = "{% url "layer_replace" resource.service_typename %}",
   time_enabled = {{ TIME_ENABLED|lower  }},
-  mosaic_enabled = {{ MOSAIC_ENABLED|lower  }},
-  userLookup = "{% url "account_ajax_lookup" %}"
+  mosaic_enabled = {{ MOSAIC_ENABLED|lower  }}
 
 {% endautoescape %}
 

--- a/geonode/layers/templates/layers/layer_style_upload.html
+++ b/geonode/layers/templates/layers/layer_style_upload.html
@@ -131,8 +131,7 @@
       csrf_token =  "{{ csrf_token }}",
       form_target = "{{ LAYER_ANCILLARY_FILES_UPLOAD_URL }}",
       time_enabled = false,
-      mosaic_enabled = false,
-      userLookup = "{% url "account_ajax_lookup" %}"
+      mosaic_enabled = false
 
     {% endautoescape %}
 

--- a/geonode/layers/templates/upload/layer_upload.html
+++ b/geonode/layers/templates/upload/layer_upload.html
@@ -132,8 +132,7 @@
   csrf_token =  "{{ csrf_token }}",
   form_target = "{{ UPLOADER_URL }}",
   time_enabled = {{ TIME_ENABLED|lower  }},
-  mosaic_enabled = {{ MOSAIC_ENABLED|lower  }},
-  userLookup = "{% url "account_ajax_lookup" %}"
+  mosaic_enabled = {{ MOSAIC_ENABLED|lower  }}
 
 {% endautoescape %}
 

--- a/geonode/templates/_permissions_form_js.html
+++ b/geonode/templates/_permissions_form_js.html
@@ -267,21 +267,21 @@
 
         $(id).select2({
           ajax: {
-            url: '{% url "account_ajax_lookup" %}',
+            url: '/api/profiles/',
             dataType: 'json',
             delay: 250,
-            type: "POST",
+            type: "GET",
             data: function (params) {
               return {
-                query: params.term,
+                username__icontains: params.term,
                 page: params.page || 1,
                 pageSize: 9
               };
             },
             processResults: function (data, params) {
-              if (data.users.length)
+              if (data.objects.length)
                 return {
-                  results: data.users.map(d => ({ id: d.username, name: d.username })),
+                  results: data.objects.map(d => ({ id: d.username, name: d.username })),
                   pagination: {
                     // more: !!data.paging.next
                     more: false
@@ -344,21 +344,21 @@
 
         $(id).select2({
           ajax: {
-            url: '{% url "account_ajax_lookup" %}',
+            url: '/api/group_profile/',
             dataType: 'json',
             delay: 250,
-            type: "POST",
+            type: "GET",
             data: function (params) {
               return {
-                query: params.term,
+                title__icontains: params.term,
                 page: params.page || 1,
                 pageSize: 9
               };
             },
             processResults: function (data, params) {
-              if (data.groups.length)
+              if (data.objects.length)
                 return {
-                  results: data.groups.map(d => ({ id: d.name, name: d.title })),
+                  results: data.objects.map(d => ({ id: d.slug, name: d.title })),
                   pagination: {
                     // more: !!data.paging.next
                     more: false

--- a/geonode/tests/test_rest_api.py
+++ b/geonode/tests/test_rest_api.py
@@ -20,7 +20,7 @@ from unittest.mock import patch, MagicMock
 
 from django.contrib.auth.models import AnonymousUser, Group
 
-from geonode.api.authorization import GroupAuthorization, GroupProfileAuthorization
+from geonode.api.authorization import GroupAuthorization, GroupProfileAuthorization, ProfileAuthorization
 from geonode.groups.models import GroupProfile
 from geonode.people.models import Profile
 from geonode.tests.base import GeoNodeBaseTestSupport
@@ -170,3 +170,139 @@ class TestGroupProfileResAuthorization(GeoNodeBaseTestSupport):
 
         groups = GroupProfileAuthorization().read_list(['not_empty_but_fake'], mock_bundle)
         self.assertEqual(1, groups.count())
+
+
+class TestProfileAuthorization(GeoNodeBaseTestSupport):
+
+    # def add_user_to_public_group(self):
+
+    def setUp(self):
+        self.u = Profile.objects.create_user(username='new_public_user', email="zaq@ws.com")
+        # public group from fixture
+        g = GroupProfile.objects.get(title='bar')
+
+        # private group from fixture
+        self.p_g = GroupProfile.objects.get(title='Registered Members')
+
+        # adjust groups to test cases
+        self.p_g.leave(self.u)
+        g.join(self.u)
+
+        self._prepare_another_test_group()
+
+    def _prepare_another_test_group(self):
+        g = Group.objects.create(name='test')
+        u = Profile.objects.create_user(username='test_priv_user', email="zaaq@ws.com")
+        gp = GroupProfile.objects.create(title='test', access='private', group=g)
+        self.p_g.leave(u)
+        gp.join(u)
+
+    @patch('geonode.api.authorization.ApiLockdownAuthorization.read_list',
+           return_value=Profile.objects.exclude(username='AnonymousUser'))
+    def test_anonymous_user(self, profile_list):
+        public_users_count = 1
+        mock_bundle = MagicMock()
+        request_mock = MagicMock()
+        r_attr = {
+            'user': AnonymousUser()
+        }
+        attrs = {
+            'request': request_mock
+        }
+        request_mock.configure_mock(**r_attr)
+        mock_bundle.configure_mock(**attrs)
+        users = ProfileAuthorization().read_list(profile_list, mock_bundle)
+        self.assertEqual(public_users_count, users.count())
+
+    @patch('geonode.api.authorization.ApiLockdownAuthorization.read_list',
+           return_value=Profile.objects.exclude(username='AnonymousUser'))
+    def test_public_group_user(self, profile_list):
+        public_users_count = 1
+        mock_bundle = MagicMock()
+        request_mock = MagicMock()
+        r_attr = {
+            'user': self.u
+        }
+        attrs = {
+            'request': request_mock
+        }
+        request_mock.configure_mock(**r_attr)
+        mock_bundle.configure_mock(**attrs)
+        users = ProfileAuthorization().read_list(profile_list, mock_bundle)
+        self.assertEqual(public_users_count, users.count())
+
+    @patch('geonode.api.authorization.ApiLockdownAuthorization.read_list',
+           return_value=Profile.objects.exclude(username='AnonymousUser'))
+    def test_private_group_user(self, profile_list):
+        # private and public users
+        expected_users_count = 4
+        mock_bundle = MagicMock()
+        request_mock = MagicMock()
+        r_attr = {
+            'user': Profile.objects.get(username='norman')
+        }
+        attrs = {
+            'request': request_mock
+        }
+        request_mock.configure_mock(**r_attr)
+        mock_bundle.configure_mock(**attrs)
+        users = ProfileAuthorization().read_list(profile_list, mock_bundle)
+        self.assertEqual(expected_users_count, users.count())
+
+    @patch('geonode.api.authorization.ApiLockdownAuthorization.read_list',
+           return_value=Profile.objects.exclude(username='AnonymousUser'))
+    def test_private_another_private_user(self, profile_list):
+        # private users of user private (1) and public (1) group
+        expected_users_count = 2
+        mock_bundle = MagicMock()
+        request_mock = MagicMock()
+        r_attr = {
+            'user': Profile.objects.get(username='test_priv_user')
+        }
+        attrs = {
+            'request': request_mock
+        }
+        request_mock.configure_mock(**r_attr)
+        mock_bundle.configure_mock(**attrs)
+        users = ProfileAuthorization().read_list(profile_list, mock_bundle)
+        self.assertEqual(expected_users_count, users.count())
+
+    @patch('geonode.api.authorization.ApiLockdownAuthorization.read_list',
+           return_value=Profile.objects.exclude(username='AnonymousUser'))
+    def test_private_both_private_user(self, profile_list):
+        # private users of all groups
+        expected_users_count = 5
+        user = Profile.objects.get(username='test_priv_user')
+        self.p_g.join(user)
+        mock_bundle = MagicMock()
+        request_mock = MagicMock()
+        r_attr = {
+            'user': Profile.objects.get(username='test_priv_user')
+        }
+        attrs = {
+            'request': request_mock
+        }
+        request_mock.configure_mock(**r_attr)
+        mock_bundle.configure_mock(**attrs)
+        users = ProfileAuthorization().read_list(profile_list, mock_bundle)
+        self.assertEqual(expected_users_count, users.count())
+
+    @patch('geonode.api.authorization.ApiLockdownAuthorization.read_list',
+           return_value=Profile.objects.exclude(username='AnonymousUser'))
+    def test_private_admin_user(self, profile_list):
+        # private and public users
+        expected_users_count = 5
+        mock_bundle = MagicMock()
+        request_mock = MagicMock()
+        r_attr = {
+            'user': Profile.objects.get(username='admin')
+        }
+        attrs = {
+            'request': request_mock
+        }
+        request_mock.configure_mock(**r_attr)
+        mock_bundle.configure_mock(**attrs)
+        users = ProfileAuthorization().read_list(profile_list, mock_bundle)
+        self.assertEqual(expected_users_count, users.count())
+
+

--- a/geonode/urls.py
+++ b/geonode/urls.py
@@ -136,9 +136,6 @@ urlpatterns += [
     url(r'^account/ajax_login$',
         geonode.views.ajax_login,
         name='account_ajax_login'),
-    url(r'^account/ajax_lookup$',
-        geonode.views.ajax_lookup,
-        name='account_ajax_lookup'),
     url(
         r'^account/moderation_sent/(?P<inactive_user>[^/]*)$',
         geonode.views.moderator_contacted,

--- a/geonode/views.py
+++ b/geonode/views.py
@@ -71,35 +71,6 @@ def ajax_login(request):
             status=400)
 
 
-def ajax_lookup(request):
-    if request.method != 'POST':
-        return HttpResponse(
-            content='ajax user lookup requires HTTP POST',
-            status=405,
-            content_type='text/plain'
-        )
-    elif 'query' not in request.POST:
-        return HttpResponse(
-            content='use a field named "query" to specify a prefix to filter usernames',
-            content_type='text/plain')
-    keyword = request.POST['query']
-    users = get_user_model().objects.filter(Q(username__icontains=keyword)).exclude(Q(username='AnonymousUser') |
-                                                                                    Q(is_active=False))
-    groups = GroupProfile.objects.filter(Q(title__icontains=keyword) |
-                                         Q(slug__icontains=keyword))
-    json_dict = {
-        'users': [({'username': u.username}) for u in users],
-        'count': users.count(),
-    }
-
-    json_dict['groups'] = [({'name': g.slug, 'title': g.title})
-                           for g in groups]
-    return HttpResponse(
-        content=json.dumps(json_dict),
-        content_type='text/plain'
-    )
-
-
 def err403(request, exception):
     if not request.user.is_authenticated:
         return HttpResponseRedirect(


### PR DESCRIPTION
https://github.com/geosolutions-it/mapstand-geonode/issues/21

Restrict GroupProfileResource and ProfileResource endpoints to fit following logic:
- Return all public items and private items which user is member of  
- remove ajax_lookup endpoint which was an alternative way to fetch Profile and GroupProfile
- use Profile and GroupProfile resources in permission autocomplete on frontend side 

Since lots of functionalities bases on membership of particular group we should consider create indexes on columns linking Group, GroupProfile and Profile or consider direct link between Profile and GroupProfile 