### PR TITLE
prevent force insert on singleton model

### DIFF
--- a/geonode/singleton.py
+++ b/geonode/singleton.py
@@ -43,6 +43,7 @@ class SingletonModel(models.Model):
 
     def save(self, *args, **kwargs):
         self.pk = 1
+        kwargs.update({'force_insert': False})
         super().save(*args, **kwargs)
 
     def delete(self, *args, **kwargs):


### PR DESCRIPTION
This is the least effort solution, next step would be add manager which will prevent direct creation of objects, and query set which will prevent direct deletion like here: https://github.com/mapstand/djam/blob/d6fe514257011e7e85d7d1ed1968002298616b40/project/apps/global_configuration/models.py#L4